### PR TITLE
Fix button text color for Gmail client

### DIFF
--- a/templates/verify-email.html
+++ b/templates/verify-email.html
@@ -137,7 +137,7 @@
       width: 200px;
       background-color: #414EF9;
       border-radius: 3px;
-      color: #ffffff;
+      color: #ffffff !important;
       font-size: 15px;
       line-height: 45px;
       text-align: center;


### PR DESCRIPTION
* which specifies bluish text color which is almost invisible on the button;
* by adding "!important" to our text color styles.

![button_in_gmail_client](https://user-images.githubusercontent.com/2342155/62157555-c1dddc00-b30d-11e9-80ac-6145bd4b65ba.png)

![fixed_button_in_gmail_client](https://user-images.githubusercontent.com/2342155/62157573-c904ea00-b30d-11e9-8588-c95f0e5a2ba3.png)
